### PR TITLE
Implement a solution for printPrice

### DIFF
--- a/app/MainT.hs
+++ b/app/MainT.hs
@@ -3,11 +3,13 @@ module Main where
 import qualified Config as C
 import qualified Transformer as T
 
+import CoinberryApi
 import Control.Monad.Reader
 
 main :: IO ()
 main = do
-    context <- C.makeContext print
+    context <- C.makeContext print price
     flip runReaderT context $ do
         T.printCurrency 
         T.printQuiet
+        T.printPrice

--- a/app/Price.hs
+++ b/app/Price.hs
@@ -3,11 +3,12 @@ module Main where
 import qualified Config as C
 import qualified Transformer as T
 
+import CoinberryApi
 import Control.Monad.Reader
 
 main :: IO ()
 main = do
-    context <- C.makeContext print
+    context <- C.makeContext print price
     flip runReaderT context $ do
         T.printCurrency
         T.printPrice

--- a/src/CoinberryApi.hs
+++ b/src/CoinberryApi.hs
@@ -1,5 +1,6 @@
 module CoinberryApi ( price
                     , Currency (..)
+                    , Price (..)
                     ) where
 
 import Control.Monad.IO.Class
@@ -27,4 +28,4 @@ instance FromJSON Price where
 
 
 data Currency = CAD | BTC | ETH | LTC | XRP 
-    deriving (Show)
+    deriving (Read, Show)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -7,6 +7,7 @@ module Config
     , load
     ) where
 
+import CoinberryApi
 import Env
 import Control.Monad.IO.Class
 
@@ -14,17 +15,18 @@ import Control.Monad.IO.Class
 data Context =
     Context { ctxPrint :: String -> IO ()
             , ctxConfig :: Config
+            , ctxPrice :: Currency -> IO Price
             }
 
 -- | This will load Config from OS environment variables. Change this to implement the `price` executable.
-makeContext :: MonadIO m => (String -> IO ()) -> m Context
-makeContext p =
-    load >>= makeContextWithConfig p
+makeContext :: MonadIO m => (String -> IO ()) -> (Currency -> IO Price) -> m Context
+makeContext p priceFn =
+    load >>= makeContextWithConfig p priceFn
 
 -- | This will build a Context with a given Config, useful for testing.
-makeContextWithConfig :: MonadIO m => (String -> IO ()) -> Config -> m Context
-makeContextWithConfig printFn config = 
-    pure $ Context printFn config
+makeContextWithConfig :: MonadIO m => (String -> IO ()) -> (Currency -> IO Price) -> Config -> m Context
+makeContextWithConfig printFn priceFn config = 
+    pure $ Context printFn config priceFn
 
 data Config =
     Config 

--- a/src/Transformer.hs
+++ b/src/Transformer.hs
@@ -6,6 +6,7 @@ module Transformer
     , printPrice
     ) where
 
+import CoinberryApi
 import Config
 import Control.Monad.Reader
 
@@ -13,7 +14,11 @@ type App = ReaderT Context IO
 
 -- | Function to be implemented.
 printPrice :: App ()
-printPrice = error "please implement printPrice to fetch currency price"
+printPrice = do
+    ctx <- ask
+    marketPrice <- liftIO . ctxPrice ctx . read . currency $ ctxConfig ctx
+    let cfgCurrency = currency (ctxConfig ctx)
+    liftIO $ ctxPrint ctx $ ("The price of " <> cfgCurrency) <> (" is " <> (buy marketPrice))
 
 -- | Using the configuration and print function from Context will print the Currency
 printCurrency :: App ()

--- a/test/TransformerSpec.hs
+++ b/test/TransformerSpec.hs
@@ -4,23 +4,31 @@ import Test.Hspec
 import Control.Monad.Reader
 import Data.IORef
 
+import CoinberryApi
 import Config
 import Transformer
 
 spec :: Spec
 spec =
     describe "Transformer" $ do
-        describe "printPrice" $
-            it "Creates message using prices from API" $
-                pendingWith "Create a spec for printPrice similar to printCurrency bellow and then implement Transformer.printCurrency"
+        describe "printPrice" $ do
+            it "Creates message using prices from API" $ do
+                result <- newIORef ""
+                let
+                    config = Config "BTC" True
+                    writeString = writeIORef result
+                context <- makeContextWithConfig writeString (const (pure $ Price "42" "23")) config 
+                runReaderT printPrice context
+                resultString <- readIORef result
+                resultString `shouldBe` "The price of BTC is 23"
 
         describe "printCurrency" $
             it "Creates message using currency configuration from context" $ do
                 result <- newIORef ""
-                let 
+                let
                     config = Config "BTC" True
                     writeString = writeIORef result
-                context <- makeContextWithConfig writeString config
+                context <- makeContextWithConfig writeString (\currency -> pure $ Price "42" "23") config 
                 runReaderT printCurrency context
                 resultString <- readIORef result
                 resultString `shouldBe` "The currency given to App is BTC"


### PR DESCRIPTION
This approach allows a stub version of `price` to be injected in from tests, while passing down a real implementation of `price` from the `CoinberryApi` in the executable modules.